### PR TITLE
Fix spend

### DIFF
--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/controllers/FetchRewardsController.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/controllers/FetchRewardsController.java
@@ -52,14 +52,17 @@ public class FetchRewardsController {
     public EntityModel<Transaction> addTransaction(@PathVariable Long id, @RequestBody String json) {
         Account account = accounts.findById(id).orElseThrow(() -> new AccountNotFoundException(id));
         JsonNode parser;
+        String payer;
+        Integer points;
+        String timestamp;
         try {
             parser = mapper.readTree(json);
-        } catch (JsonProcessingException e) {
+            payer = parser.get("payer").asText();
+            points = parser.get("points").asInt();
+            timestamp = parser.get("timestamp").asText();
+        } catch (JsonProcessingException | NullPointerException e) {
             throw new JsonParseException(json); //  handle bad json parse
         }
-        String payer = parser.get("payer").asText();
-        Integer points = parser.get("points").asInt();
-        String timestamp = parser.get("timestamp").asText();
 
         /* Validate JSON data */
         if (validate(payer)) {
@@ -91,12 +94,13 @@ public class FetchRewardsController {
     public CollectionModel<Transaction> spend(@PathVariable Long id, @RequestBody String json) {
         Account account = accounts.findById(id).orElseThrow(() -> new AccountNotFoundException(id));
         JsonNode parser;
+        Integer points;
         try {
             parser = mapper.readTree(json);
-        } catch (JsonProcessingException e) {
+            points = parser.get("points").asInt();
+        } catch (JsonProcessingException | NullPointerException e) {
             throw new JsonParseException(json); //  handle bad json parse
         }
-        Integer points = parser.get("points").asInt();
 
         /* Validate JSON data */
         if (validate(points)) {

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/controllers/FetchRewardsController.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/controllers/FetchRewardsController.java
@@ -39,7 +39,7 @@ public class FetchRewardsController {
     private final ObjectMapper mapper;
 
     /*
-    * Return a JSON of account info, such as name, points, payers, and transactions
+    * Return a JSON of account info, such as name, points, payers, and transactions (for debugging purposes)
     * */
     @GetMapping(value = "/api/{id}/account/")
     public EntityModel<Account> getAccount(@PathVariable Long id) {
@@ -125,6 +125,17 @@ public class FetchRewardsController {
     public CollectionModel<Payer> checkBalance(@PathVariable Long id) {
         Account account = accounts.findById(id).orElseThrow(() -> new AccountNotFoundException(id));  //  handle 404 exception
         return service.checkBalance(id, payers.findAllByAccount(account));
+    }
+
+    /*
+    * Remove all transactions and payers from account (for unit testing purposes)
+    * */
+    @DeleteMapping(value = "/api/{id}/delete/")
+    public EntityModel<Account> deleteEverything(@PathVariable Long id) {
+        accounts.findById(id).orElseThrow(() -> new AccountNotFoundException(id)).setPoints(0);
+        accounts.deleteTransactions(id);
+        accounts.deletePayers(id);
+        return getAccount(id);
     }
 
     private <T> boolean validate(T obj) {

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/controllers/FetchRewardsController.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/controllers/FetchRewardsController.java
@@ -103,7 +103,7 @@ public class FetchRewardsController {
         }
 
         /* Validate JSON data */
-        if (validate(points)) {
+        if (validate(points) || points < 0) {
             throw new BadInputException("points", points);  //  handle if zero or null
         }
 
@@ -139,9 +139,9 @@ public class FetchRewardsController {
     }
 
     private <T> boolean validate(T obj) {
-        return ((obj == null)
-                || ((obj instanceof String) && ((((String) obj).isBlank()) || (((String) obj).isEmpty()))
-                || ((obj instanceof Integer) && ((Integer) obj == 0))));
+        return ((obj instanceof String) && ((((String) obj).isBlank()) || (((String) obj).isEmpty())
+                || (obj.equals("null")))
+                || ((obj instanceof Integer) && ((Integer) obj == 0)));
     }
 
     private Date validateTimestamp(String timestamp) {

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/exceptions/BadInputException.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/exceptions/BadInputException.java
@@ -3,6 +3,6 @@ package com.fetchrewards.fetchrewardsexercise.exceptions;
 public class BadInputException extends RuntimeException {
     public <T> BadInputException(String field, T value) {
         super("JSON field " + field + " has value '" + value
-                + "', which is either zero, null, blank, or of a bad format.");
+                + "', which is either null, blank, negative, or of a bad format.");
     }
 }

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/model/Transaction.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/model/Transaction.java
@@ -15,7 +15,7 @@ import java.util.Calendar;
 @NoArgsConstructor
 public abstract class Transaction extends BasicEntity {
     @NonNull
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'hh:mm:ss'Z'")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'")
     protected Calendar timestamp;
 
     @NonNull

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/model/TransactionImpl.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/model/TransactionImpl.java
@@ -16,4 +16,8 @@ public class TransactionImpl extends Transaction {
         setPoints(points);
     }
 
+    public TransactionImpl(@NonNull Payer payer, @NonNull Account account) {
+        this.payer = payer;
+        this.account = account;
+    }
 }

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/repositories/AccountRepository.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/repositories/AccountRepository.java
@@ -13,4 +13,14 @@ public interface AccountRepository extends CrudRepository<Account, Long> {
     @Transactional
     @Query("Update Account a set a.points=a.points+:points where a.id=:id")
     void addPoints(@Param("id") Long id, @Param("points") Integer points);
+
+    @Modifying
+    @Transactional
+    @Query("Delete from Payer p where p.account.id=:id")
+    void deletePayers(@Param("id") Long id);
+
+    @Modifying
+    @Transactional
+    @Query("Delete from Transaction t where t.account.id=:id")
+    void deleteTransactions(@Param("id") Long id);
 }

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/services/AccountService.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/services/AccountService.java
@@ -4,10 +4,11 @@ import com.fetchrewards.fetchrewardsexercise.model.Payer;
 import com.fetchrewards.fetchrewardsexercise.model.Transaction;
 import org.springframework.hateoas.CollectionModel;
 
+import java.util.Date;
 import java.util.List;
 
 public interface AccountService {
-    Transaction addTransaction(Payer payer, Integer points, String timestamp);
+    Transaction addTransaction(Payer payer, Integer points, Date timestamp);
     CollectionModel<Payer> checkBalance(Long id, List<Payer> payers);
     List<Transaction> spend(Integer spend, List<Transaction> transactions, List<Payer> payers);
 }

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/services/AccountServiceImpl.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/services/AccountServiceImpl.java
@@ -45,7 +45,7 @@ public class AccountServiceImpl implements AccountService {
             Payer payer = transaction.getPayer();
 
             /* Reduce time complexity by adding new transactions as they are necessary */
-            Transaction newTransaction = newTransactions.getOrDefault(payer, new TransactionImpl());
+            Transaction newTransaction = newTransactions.getOrDefault(payer, new TransactionImpl(payer, payer.getAccount()));
             if (spend >= transaction.getPoints()) {
                 if (payer.getPoints() - transaction.getPoints() >= 0) {
                     spend -= transaction.getPoints();
@@ -86,7 +86,7 @@ public class AccountServiceImpl implements AccountService {
             for (Payer payer : payers) {
 
                 /* In case payers are still not in hashmap */
-                Transaction newTransaction = newTransactions.getOrDefault(payer, new TransactionImpl());
+                Transaction newTransaction = newTransactions.getOrDefault(payer, new TransactionImpl(payer, payer.getAccount()));
 
                 /* Prevent error with transactions of zero points from adding to payer's points */
                 if (payer.getPoints() == 0) {
@@ -108,8 +108,6 @@ public class AccountServiceImpl implements AccountService {
         /* Remove any remaining transactions of zero points and add necessary data */
         return newTransactions.values().stream().filter(transaction -> {
             transaction.setTimestamp(Calendar.getInstance());
-            transaction.setPayer(transaction.getPayer());
-            transaction.setAccount(transaction.getAccount());
             return transaction.getPoints() != 0;    // return lambda
         }).toList();
     }

--- a/src/main/java/com/fetchrewards/fetchrewardsexercise/services/AccountServiceImpl.java
+++ b/src/main/java/com/fetchrewards/fetchrewardsexercise/services/AccountServiceImpl.java
@@ -8,6 +8,7 @@ import org.springframework.hateoas.CollectionModel;
 import org.springframework.stereotype.Service;
 
 import java.util.Calendar;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
@@ -18,17 +19,8 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 public class AccountServiceImpl implements AccountService {
 
     @Override
-    public Transaction addTransaction(Payer payer, Integer points, String timestamp) {
-        Calendar time = new Calendar.Builder().setDate(
-                Integer.parseInt(timestamp.substring(0, 4)),
-                Integer.parseInt(timestamp.substring(5, 7)) - 1,
-                Integer.parseInt(timestamp.substring(8, 10))
-        ).setTimeOfDay(
-                Integer.parseInt(timestamp.substring(11, 13)),
-                Integer.parseInt(timestamp.substring(14, 16)),
-                Integer.parseInt(timestamp.substring(17, 19))
-        ).build();
-
+    public Transaction addTransaction(Payer payer, Integer points, Date timestamp) {
+        Calendar time = new Calendar.Builder().setInstant(timestamp).build();
         return new TransactionImpl(points, time, payer, payer.getAccount());
     }
 

--- a/src/test/java/com/fetchrewards/fetchrewardsexercise/FetchRewardsExerciseApplicationTests.java
+++ b/src/test/java/com/fetchrewards/fetchrewardsexercise/FetchRewardsExerciseApplicationTests.java
@@ -1,13 +1,217 @@
 package com.fetchrewards.fetchrewardsexercise;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
+@AutoConfigureMockMvc
 class FetchRewardsExerciseApplicationTests {
 
+    /*
+    * IntelliJ incorrectly complains "Could not autowire. No beans of 'MockMvc' type found."
+    * Whether the annotation is commented out or not, the code works
+    * */
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    @Autowired
+    private MockMvc mockMvc;
+    private final Long ID = 1L;
+
+
+    @DisplayName("account not found")
     @Test
-    void contextLoads() {
+    void test1() throws Exception {
+        mockMvc.perform(get("/api/{id}/balance/", 2L)).andExpect(status().isNotFound());
+        mockMvc.perform(put("/api/{id}/spend/", (-2L))
+                .contentType(MediaType.APPLICATION_JSON).content("{}")).andExpect(status().isNotFound());
+        mockMvc.perform(post("/api/{id}/transaction/", 0L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")).andExpect(status().isNotFound());
+    }
+    @DisplayName("bad json parse")
+    @Test
+    void test2() throws Exception {
+        mockMvc.perform(post("/api/{id}/transaction/", ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")).andExpect(status().isBadRequest());
+        mockMvc.perform(post("/api/{id}/transaction/", ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"payer\": \"DANNON\"}")).andExpect(status().isBadRequest());
+        mockMvc.perform(put("/api/{id}/spend/", ID)
+                .contentType(MediaType.APPLICATION_JSON).content("{}")).andExpect(status().isBadRequest());
+        mockMvc.perform(put("/api/{id}/spend/", ID)
+                .contentType(MediaType.APPLICATION_JSON).content("{\"spen\": 1000}")).andExpect(status().isBadRequest());
+    }
+    @DisplayName("insufficient points")
+    @Test
+    void test3() throws Exception {
+        spend(1000).andExpect(status().isNotAcceptable());
+        addTransaction("DANNON", 1000, "2020-11-02T14:00:00Z");
+        spend(2000).andExpect(status().isNotAcceptable());
+    }
+    @DisplayName("bad timestamp")
+    @Test
+    void test4() throws Exception {
+        addTransaction("DANNON", 1000, "2020-11-02T14:00:00").andExpect(status().isBadRequest());
+        addTransaction("DANNON", 1000, "").andExpect(status().isBadRequest());
+    }
+    @DisplayName("null payer in transaction")
+    @Test
+    void test5() throws Exception {
+        String json = "{\"payer\": null, \"points\": 1000, \"timestamp\": \"2020-11-02T14:00:00Z\"}";
+        mockMvc.perform(post("/api/{id}/transaction/", ID).content(json)).andExpect(status().isBadRequest());
+        addTransaction(null, 1000, "2020-11-02T14:00:00Z").andExpect(status().isBadRequest());
+    }
+    @DisplayName("empty payer in transaction")
+    @Test
+    void test6() throws Exception {
+        String json = "{\"payer\": , \"points\": 1000, \"timestamp\": \"2020-11-02T14:00:00Z\"}";
+        mockMvc.perform(post("/api/{id}/transaction/", ID).content(json)).andExpect(status().isBadRequest());
+        addTransaction("", 1000, "2020-11-02T14:00:00Z").andExpect(status().isBadRequest());
+    }
+    @DisplayName("blank payer in transaction")
+    @Test
+    void test7() throws Exception {
+        addTransaction("   ", 1000, "2020-11-02T14:00:00Z").andExpect(status().isBadRequest());
+    }
+    @DisplayName("null points in transaction")
+    @Test
+    void test8() throws Exception {
+        String json = "{\"payer\": \"DANNON\", \"points\": null, \"timestamp\": \"2020-11-02T14:00:00Z\"}";
+        mockMvc.perform(post("/api/{id}/transaction/", ID).content(json)).andExpect(status().isBadRequest());
+        json = "{\"payer\": \"DANNON\", \"points\": \"null\", \"timestamp\": \"2020-11-02T14:00:00Z\"}";
+        mockMvc.perform(post("/api/{id}/transaction/", ID).content(json)).andExpect(status().isBadRequest());
+    }
+    @DisplayName("zero points in transaction")
+    @Test
+    void test9() throws Exception {
+        String json = "{\"payer\": \"DANNON\", \"points\": 0, \"timestamp\": \"2020-11-02T14:00:00Z\"}";
+        mockMvc.perform(post("/api/{id}/transaction/", ID).content(json)).andExpect(status().isBadRequest());
+        addTransaction("DANNON", 0, "2020-11-02T14:00:00Z").andExpect(status().isBadRequest());
+    }
+    @DisplayName("timestamp in the future")
+    @Test
+    void test10() throws Exception {
+        addTransaction("DANNON", 1000, "2075-11-02T14:00:00Z").andExpect(status().isBadRequest());
+    }
+    @DisplayName("points are negative")
+    @Test
+    void test11() throws Exception {
+        spend(-1000).andExpect(status().isBadRequest());
+        addTransaction("DANNON", 1000, "2020-11-02T14:00:00Z");
+        spend(-1000).andExpect(status().isBadRequest());
+    }
+    @DisplayName("spend 5000 (5 Transactions, 3 Payers)")
+    @Test
+    void test12() throws Exception {
+        exampleTransactions();
+        spend(5000).andExpect(sumOfPoints(-5000))
+                .andExpect(spendCheck("DANNON", -100))
+                .andExpect(spendCheck("MILLER COORS", -4700))
+                .andExpect(spendCheck("UNILEVER", -200));
+        balance().andExpect(sumOfPoints(6300))
+                .andExpect(balanceCheck("DANNON", 1000))
+                .andExpect(balanceCheck("MILLER COORS", 5300))
+                .andExpect(balanceCheck("UNILEVER", 0));
     }
 
+    @DisplayName("Spend 1000 (5 Transactions, 3 Payers)")
+    @Test
+    void test13() throws Exception {
+        exampleTransactions();
+        spend(1000).andExpect(sumOfPoints(-1000))
+                .andExpect(spendCheck("DANNON", -100))
+                .andExpect(spendCheck("MILLER COORS", -700))
+                .andExpect(spendCheck("UNILEVER", -200));
+        balance().andExpect(sumOfPoints(10300))
+                .andExpect(balanceCheck("DANNON", 1000))
+                .andExpect(balanceCheck("MILLER COORS", 9300))
+                .andExpect(balanceCheck("UNILEVER", 0));
+    }
+
+    @DisplayName("Spend all (1 payer)")
+    @Test
+    void test14() throws Exception {
+        addTransaction("DANNON", 1000, "2020-11-02T14:00:00Z");
+        spend(1000).andExpect(sumOfPoints(-1000)).andExpect(spendCheck("DANNON", -1000));
+    }
+    @DisplayName("Spend 5000, 3000 (5 Transactions, 3 Payers)")
+    @Test
+    void test15() throws Exception {
+        exampleTransactions();
+        spend(5000);
+        spend(3000).andExpect(sumOfPoints(-3000))
+                .andExpect(spendCheck("DANNON", (-100)))
+                .andExpect(spendCheck("MILLER COORS", (-2900)));
+        balance().andExpect(sumOfPoints(3300))
+                .andExpect(balanceCheck("DANNON", 900))
+                .andExpect(balanceCheck("MILLER COORS", 2400))
+                .andExpect(balanceCheck("UNILEVER", 0));
+    }
+    @DisplayName("Spend 5000, 5000 (5 Transactions, 3 Payers)")
+    @Test
+    void test16() throws Exception {
+        exampleTransactions();
+        spend(5000);
+        spend(5000).andExpect(sumOfPoints(-5000))
+                .andExpect(spendCheck("DANNON", (-100)))
+                .andExpect(spendCheck("MILLER COORS", (-4900)));
+        balance().andExpect(sumOfPoints(1300))
+                .andExpect(balanceCheck("DANNON", 900))
+                .andExpect(balanceCheck("MILLER COORS", 400))
+                .andExpect(balanceCheck("UNILEVER", 0));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        mockMvc.perform(delete("/api/{id}/delete/", ID));
+    }
+
+    private void exampleTransactions() throws Exception {
+        addTransaction("DANNON", 1000, "2020-11-02T14:00:00Z");
+        addTransaction("UNILEVER", 200, "2020-10-31T11:00:00Z");
+        addTransaction("DANNON", -200, "2020-10-31T15:00:00Z");
+        addTransaction("MILLER COORS", 10000, "2020-11-01T14:00:00Z");
+        addTransaction("DANNON", 300, "2020-10-31T10:00:00Z");
+    }
+
+    private ResultMatcher sumOfPoints(int points) {
+        return jsonPath("$..points.sum()").value(points);
+    }
+
+    private ResultMatcher balanceCheck(String payer, int points) {
+        return jsonPath(String.format("$..payerImplList[?(@.name == '%s')].points", payer)).value(points);
+    }
+
+    private ResultMatcher spendCheck(String payer, int points) {
+        return jsonPath(String.format("$..transactionImplList[?(@.payer == '%s')].points", payer)).value(points);
+    }
+
+    private ResultActions balance() throws Exception {
+        return mockMvc.perform(get("/api/{id}/balance/", ID));
+    }
+
+    private ResultActions spend(int points) throws Exception {
+        final String spendJSON = "{\"points\": %d}";
+        return mockMvc.perform(put("/api/{id}/spend/", ID)
+                .contentType(MediaType.APPLICATION_JSON).content(String.format(spendJSON, points)));
+    }
+
+    private ResultActions addTransaction(String payer, int points, String timestamp) throws Exception {
+        final String transactionJSON = "{\"payer\": \"%s\", \"points\": %d, \"timestamp\": \"%s\"}";
+        return mockMvc.perform(post("/api/{id}/transaction/", ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(String.format(transactionJSON, payer, points, timestamp)));
+    }
 }


### PR DESCRIPTION
# Cause of problem
In the stream filter method at the end of the spend method, `Transaction` metadata such as `Payer` and `Account` was assigned to itself, which was null.